### PR TITLE
Post jobs to slack when PR is merged

### DIFF
--- a/.github/workflows/post-jobs-slack.yaml
+++ b/.github/workflows/post-jobs-slack.yaml
@@ -11,6 +11,9 @@ jobs:
     name: Run Jobs Slack Poster
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
       - id: updater
         name: Job Updater
         uses: ./

--- a/.github/workflows/post-jobs-slack.yaml
+++ b/.github/workflows/post-jobs-slack.yaml
@@ -1,5 +1,5 @@
 on:
-  pull_request:
+  push:
     paths:
       - 'example/jobs.yaml'
     branches:
@@ -16,10 +16,10 @@ jobs:
         uses: ./
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-        with:        
+        with:
           filename: "example/jobs.yaml"
           key: "url"
-          
+
       - run: echo ${{ steps.updater.outputs.fields }}
         name: Show New Jobs
-        shell: bash        
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ jobs:
     name: Run Jobs Slack Poster
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
       - id: updater
         name: Job Updater
         uses: rseng/jobs-updater@main

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ and a yaml file with a list of jobs (or other links):
   url: https://my-job.org/12345
 ```
 
-The action will inspect the file to determine lines that are newly added (compared to the main branch)
+The action will inspect the file to determine lines that are newly added (compared to the parent commit)
 for a field of interest (e.g., the "url" attribute in a list of jobs), extract this field, and then post to a Slack channel.
 
 ![img/example.png](img/example.png)
@@ -44,16 +44,14 @@ and put it in a safe place. We will want to keep this URL as a secret in our eve
 
 ## 2. Usage
 
-Add an GitHub workflow file in .github/workflows to specify the following. Note that
-the workflow below will do the check and update on the opening of a pull request.
+Add an GitHub workflow file in `.github/workflows` to specify the following. Note that
+the workflow below will do the check and update on any push to main (e.g., a merged pull request).
 
 ```yaml
 on:
-  pull_request:
+  push:
     paths:
       - '_data/jobs.yml'
-    types:
-      - opened
     branches:
       - main
 
@@ -68,12 +66,11 @@ jobs:
         uses: rseng/jobs-updater@main
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-        with:        
+        with:
           filename: "_data/jobs.yml"
           key: "url"
-          
+
       - run: echo ${{ steps.updater.outputs.fields }}
         name: Show New Jobs
         shell: bash
 ```
-

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,6 @@
 name: 'Jobs Updater'
 description: "The jobs updater will respond on some trigger, and them parse a jobs file for changes, posting a field of interest to slack."
 inputs:
-  main: 
-    description: main branch to compare to (defaults to main)
-    required: false
-    default: main
   filename:
     description: the filename for the jobs
     required: true    
@@ -28,8 +24,8 @@ runs:
       id: jobs-updater
       env:
         INPUT_FILENAME: ${{ inputs.filename }}
-        INPUT_MAIN: ${{ inputs.main }}
         INPUT_KEY: ${{ inputs.key }}
+        CURRENT_SHA: ${{ github.sha }}
         ACTION_DIR: ${{ github.action_path }}
         INPUT_REPO: ${{ github.repository }}
       run: ${{ github.action_path }}/entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,8 @@ if [[ ! -f "${INPUT_FILENAME}" ]]; then
 fi
 
 # Wget the comparison file
-JOBFILE="https://raw.githubusercontent.com/${INPUT_REPO}/${INPUT_MAIN}/${INPUT_FILENAME}"
+PARENT_SHA=$(git log --pretty=%P -n 1 ${CURRENT_SHA} | cut -d ' ' -f 1)
+JOBFILE="https://raw.githubusercontent.com/${INPUT_REPO}/${PARENT_SHA}/${INPUT_FILENAME}"
 TMP=$(mktemp -d)
 
 BASENAME=$(basename ${INPUT_FILENAME})


### PR DESCRIPTION
This updates the `post-jobs-slack.yaml` workflow to be based on pushes to main, so that jobs are posted to slack when a jobs PR is merged to ensure what's posted to the website, is what's posted to slack. 

The command to get the parent commit hash:
```
PARENT_HASH=$(git log --pretty=%P -n 1 ${CURRENT_SHA} | cut -d ' ' -f 1)
```
works for both merge commits (e.g., USRSE/usrse.github.io@f4853c5) and squash commits/direct commits (e.g., USRSE/usrse.github.io@284fbb3).

I also checked to make sure it won't post when expired jobs get pruned. 

