### PR TITLE
allow multiple hashtags

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ The following variables are available. You can also look at the [action.yml](act
 | previous_filename | The previous filename (for manual tesing or running alongside update) | false | unset |
 | keys | Comma separated list of keys to post (defaults to url) | false | url |
 | unique | Field to use to determine uniqueness | true | url |
-| hashtags | A comma separated list of hashtags to use (defaults to `#Rseng`) | false | #RSEng |
+| hashtag | A comma separated list of hashtags to use (defaults to `#RSEng`) | false | #RSEng |
 | test |  Test the updater (ensure there are jobs) | true | false |
 | deploy | Global deploy across any service set to true? | true | true |
 | bluesky_deploy | Deploy to BlueSky? | true | false |

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ The following variables are available. You can also look at the [action.yml](act
 | previous_filename | The previous filename (for manual tesing or running alongside update) | false | unset |
 | keys | Comma separated list of keys to post (defaults to url) | false | url |
 | unique | Field to use to determine uniqueness | true | url |
-| hashtag | A hashtag to use (defaults to `#Rseng`) | false | #RSEng |
+| hashtags | A comma separated list of hashtags to use (defaults to `#Rseng`) | false | #RSEng |
 | test |  Test the updater (ensure there are jobs) | true | false |
 | deploy | Global deploy across any service set to true? | true | true |
 | bluesky_deploy | Deploy to BlueSky? | true | false |

--- a/action.yml
+++ b/action.yml
@@ -15,8 +15,8 @@ inputs:
     description: Field to use to determine uniqueness
     required: true
     default: url
-  hashtag:
-    description: A hashtag to use (defaults to <hashtag>Rseng)
+  hashtags:
+    description: A comma separated list of hashtags to use (defaults to <hashtag>Rseng)
     required: false
     default: "#RSEng"
   test:
@@ -117,7 +117,7 @@ runs:
         ACTION_DIR: ${{ github.action_path }}
         INPUT_REPO: ${{ github.repository }}
         INPUT_TEST: ${{ inputs.test }}
-        INPUT_HASHTAG: ${{ inputs.hashtag }}
+        INPUT_HASHTAGS: ${{ inputs.hashtags }}
         INPUT_DEPLOY: ${{ inputs.deploy }}
         SLACK_DEPLOY: ${{ inputs.slack_deploy }}
         SLACK_WEBHOOK: ${{ inputs.slack_webhook }}

--- a/action.yml
+++ b/action.yml
@@ -15,8 +15,8 @@ inputs:
     description: Field to use to determine uniqueness
     required: true
     default: url
-  hashtags:
-    description: A comma separated list of hashtags to use (defaults to <hashtag>Rseng)
+  hashtag:
+    description: A comma separated list of hashtags to use (defaults to <hashtag>RSEng)
     required: false
     default: "#RSEng"
   test:
@@ -117,7 +117,7 @@ runs:
         ACTION_DIR: ${{ github.action_path }}
         INPUT_REPO: ${{ github.repository }}
         INPUT_TEST: ${{ inputs.test }}
-        INPUT_HASHTAGS: ${{ inputs.hashtags }}
+        INPUT_HASHTAG: ${{ inputs.hashtag }}
         INPUT_DEPLOY: ${{ inputs.deploy }}
         SLACK_DEPLOY: ${{ inputs.slack_deploy }}
         SLACK_WEBHOOK: ${{ inputs.slack_webhook }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -85,13 +85,13 @@ printf " Deploy Discord: ${DEPLOY_DISCORD}\n"
 printf "   Deploy Slack: ${DEPLOY_SLACK}\n"
 printf "       Original: ${JOBFILE}\n"
 printf "        Updated: ${INPUT_FILENAME}\n"
-printf "        Hashtag: ${INPUT_HASHTAG}\n"
+printf "       Hashtags: ${INPUT_HASHTAGS}\n"
 printf "         Unique: ${INPUT_UNIQUE}\n"
 printf "           Keys: ${INPUT_KEYS}\n"
 printf "           Test: ${INPUT_TEST}\n"
 
 
-COMMAND="python ${ACTION_DIR}/find-updates.py update --keys ${INPUT_KEYS} --unique ${INPUT_UNIQUE} --original ${JOBFILE} --updated ${INPUT_FILENAME} --hashtag ${INPUT_HASHTAG}"
+COMMAND="python ${ACTION_DIR}/find-updates.py update --keys ${INPUT_KEYS} --unique ${INPUT_UNIQUE} --original ${JOBFILE} --updated ${INPUT_FILENAME} --hashtags ${INPUT_HASHTAGS}"
 
 if [[ "${DEPLOY}" == "true" ]]; then
     COMMAND="${COMMAND} --deploy"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -85,13 +85,13 @@ printf " Deploy Discord: ${DEPLOY_DISCORD}\n"
 printf "   Deploy Slack: ${DEPLOY_SLACK}\n"
 printf "       Original: ${JOBFILE}\n"
 printf "        Updated: ${INPUT_FILENAME}\n"
-printf "       Hashtags: ${INPUT_HASHTAGS}\n"
+printf "        Hashtag: ${INPUT_HASHTAG}\n"
 printf "         Unique: ${INPUT_UNIQUE}\n"
 printf "           Keys: ${INPUT_KEYS}\n"
 printf "           Test: ${INPUT_TEST}\n"
 
 
-COMMAND="python ${ACTION_DIR}/find-updates.py update --keys ${INPUT_KEYS} --unique ${INPUT_UNIQUE} --original ${JOBFILE} --updated ${INPUT_FILENAME} --hashtags ${INPUT_HASHTAGS}"
+COMMAND="python ${ACTION_DIR}/find-updates.py update --keys ${INPUT_KEYS} --unique ${INPUT_UNIQUE} --original ${JOBFILE} --updated ${INPUT_FILENAME} --hashtag ${INPUT_HASHTAG}"
 
 if [[ "${DEPLOY}" == "true" ]]; then
     COMMAND="${COMMAND} --deploy"

--- a/find-updates.py
+++ b/find-updates.py
@@ -440,7 +440,7 @@ def main():
             deploy_twitter(twitter_client, newline_message)
 
         if args.deploy_bluesky and bluesky_client:
-            deploy_bluesky(bluesky_client, entry, keys, args.hashtags)
+            deploy_bluesky(bluesky_client, entry, keys, hashtags)
 
         # If we are instructed to deploy to mastodon and have a client
         if args.deploy_mastodon and mastodon_client:

--- a/find-updates.py
+++ b/find-updates.py
@@ -108,8 +108,8 @@ def get_parser():
     )
 
     update.add_argument(
-        "--hashtags",
-        dest="hashtags",
+        "--hashtag",
+        dest="hashtag",
         default="#RSEng",
         help="A comma separated list of hashtags (starting with #) to include in the post, defaults to #RSEng",
     )
@@ -293,9 +293,9 @@ def deploy_bluesky(client, entry, keys, hashtags):
     choice = random.choice(icons)
     # Add the text to the textbuilder
     # seems like a clumsy way to build such a message...
-    tb.text("New")
+    tb.text("New ")
     for hashtag in hashtags:
-        tb.text(" ").tag(hashtag, hashtag.strip("#")).text(" ")
+        tb.tag(hashtag, hashtag.lstrip("#")).text(" ")
     tb.text(f"Job! {choice}\n")
     anchor=entry.get('title') or entry.get('name') or entry.get('url')
     tb.link(anchor, entry.get('url'))
@@ -372,7 +372,7 @@ def main():
     keys = [x for x in args.keys.split(",") if x]
 
     # Parse hashtags into list
-    hashtags = [x for x in args.hashtags.split(",") if x]
+    hashtags = [x for x in args.hashtag.split(",") if x]
 
     # Find new posts in updated
     previous = set()
@@ -414,9 +414,8 @@ def main():
         # Prepare the post
         post = prepare_post(entry, keys)
         choice = random.choice(icons)
-        tags=" ".join(x for x in hashtags)
-        message = f"New {tags} Job! {choice}: {post}"
-        newline_message = f"New {tags} Job! {choice}\n{post}"
+        message = f"New {(" ".join(hashtags))} Job! {choice}: {post}"
+        newline_message = f"New {(" ".join(hashtags))} Job! {choice}\n{post}"
         print(message)
 
         # Convert dates, etc. back to string

--- a/find-updates.py
+++ b/find-updates.py
@@ -108,10 +108,10 @@ def get_parser():
     )
 
     update.add_argument(
-        "--hashtag",
-        dest="hashtag",
+        "--hashtags",
+        dest="hashtags",
         default="#RSEng",
-        help="A hashtag (starting with #) to include in the post, defaults to #RSEng",
+        help="A comma separated list of hashtags (starting with #) to include in the post, defaults to #RSEng",
     )
 
     update.add_argument(
@@ -282,7 +282,7 @@ def deploy_slack(webhook, message):
         )
 
 
-def deploy_bluesky(client, entry, keys, hashtag):
+def deploy_bluesky(client, entry, keys, hashtags):
     """
     Deploy to bluesky. We add the job link separately.
     """
@@ -291,11 +291,12 @@ def deploy_bluesky(client, entry, keys, hashtag):
     # Prepare the post, but without the url
     post = prepare_post(entry, keys, without_url=True)
     choice = random.choice(icons)
-    message = f"New {hashtag} Job! {choice}\n"
-    print(message)
-
     # Add the text to the textbuilder
-    tb.text(message)
+    # seems like a clumsy way to build such a message...
+    tb.text("New")
+    for hashtag in hashtags:
+        tb.text(" ").tag(hashtag, hashtag.strip("#")).text(" ")
+    tb.text(f"Job! {choice}\n")
     anchor=entry.get('title') or entry.get('name') or entry.get('url')
     tb.link(anchor, entry.get('url'))
     tb.text("\n" + post)
@@ -370,6 +371,9 @@ def main():
     # Parse keys into list
     keys = [x for x in args.keys.split(",") if x]
 
+    # Parse hashtags into list
+    hashtags = [x for x in args.hashtags.split(",") if x]
+
     # Find new posts in updated
     previous = set()
     missing_count = 0
@@ -410,8 +414,9 @@ def main():
         # Prepare the post
         post = prepare_post(entry, keys)
         choice = random.choice(icons)
-        message = f"New {args.hashtag} Job! {choice}: {post}"
-        newline_message = f"New {args.hashtag} Job! {choice}\n{post}"
+        tags=" ".join(x for x in hashtags)
+        message = f"New {tags} Job! {choice}: {post}"
+        newline_message = f"New {tags} Job! {choice}\n{post}"
         print(message)
 
         # Convert dates, etc. back to string
@@ -435,7 +440,7 @@ def main():
             deploy_twitter(twitter_client, newline_message)
 
         if args.deploy_bluesky and bluesky_client:
-            deploy_bluesky(bluesky_client, entry, keys, args.hashtag)
+            deploy_bluesky(bluesky_client, entry, keys, args.hashtags)
 
         # If we are instructed to deploy to mastodon and have a client
         if args.deploy_mastodon and mastodon_client:


### PR DESCRIPTION
this changeset does two things:
1) replaces the `hashtag` option with `hashtags` that takes
a comma separated list of hashtags to use

2) changes the way hashtags are prepared in the BlueSky
deployment.  Previously, those tags were just static text and
were not linkified by bsky in the text of the post
